### PR TITLE
Fix broken search button in openlayers 6

### DIFF
--- a/src/nominatim.js
+++ b/src/nominatim.js
@@ -57,7 +57,9 @@ export class Nominatim {
 
   setListeners() {
     let timeout, lastQuery;
-    const openSearch = () => {
+    const openSearch = evt => {
+      evt.stopPropagation();
+
       hasClass(this.els.control, klasses.glass.expanded)
         ? this.collapse()
         : this.expand();
@@ -76,6 +78,9 @@ export class Nominatim {
         evt.preventDefault();
         this.query(value);
       }
+    };
+    const stopBubbling = evt => {
+      evt.stopPropagation();
     };
     const reset = evt => {
       this.els.input.focus();
@@ -102,6 +107,7 @@ export class Nominatim {
       }
     };
     this.els.input.addEventListener('keypress', query, false);
+    this.els.input.addEventListener('click', stopBubbling, false);
     this.els.input.addEventListener('input', handleValue, false);
     this.els.reset.addEventListener('click', reset, false);
     if (this.options.targetType === TARGET_TYPE.GLASS) {
@@ -299,10 +305,8 @@ export class Nominatim {
   expand() {
     removeClass(this.els.input, klasses.spin);
     addClass(this.els.control, klasses.glass.expanded);
-    window.setTimeout(() => {
-      this.listenMapClick();
-      this.els.input.focus();
-    }, 100);
+    window.setTimeout(() => this.els.input.focus(), 100);
+    this.listenMapClick();
   }
 
   collapse() {

--- a/src/nominatim.js
+++ b/src/nominatim.js
@@ -299,8 +299,10 @@ export class Nominatim {
   expand() {
     removeClass(this.els.input, klasses.spin);
     addClass(this.els.control, klasses.glass.expanded);
-    window.setTimeout(() => this.els.input.focus(), 100);
-    this.listenMapClick();
+    window.setTimeout(() => {
+      this.listenMapClick();
+      this.els.input.focus();
+    }, 100);
   }
 
   collapse() {


### PR DESCRIPTION
After investigating this issue it turns out the root of the problem is that a click event on an ol-control button will bubble up to the map container element in openlayers 6, while it did not in previous versions.

The solution I came up for the time being adds a `stopPropagation()` to the glass button as well as binding a new click event on the related input that does the same to prevent map click event from firing unintentionally.

This behavior in openlayers may be considered a bug on their end, judging by issues that appear tangentially related such as https://github.com/openlayers/openlayers/issues/10091.

Closes #193 