### PR TITLE
Include bbox from Nominatim response, fixes #224

### DIFF
--- a/src/nominatim.js
+++ b/src/nominatim.js
@@ -213,7 +213,11 @@ export class Nominatim {
     let { bbox } = place;
 
     if (bbox) {
-      bbox = proj.transformExtent(bbox, 'EPSG:4326', projection);
+      bbox = proj.transformExtent(
+        [bbox[2], bbox[1], bbox[3], bbox[0]], // NSWE -> WSEN
+        'EPSG:4326',
+        projection
+      );
     }
 
     const address = {
@@ -230,6 +234,7 @@ export class Nominatim {
         address,
         coordinate: coord,
         bbox,
+        place,
       });
     } else {
       if (bbox) {
@@ -246,6 +251,7 @@ export class Nominatim {
         feature,
         coordinate: coord,
         bbox,
+        place,
       });
     }
   }

--- a/src/providers/osm.js
+++ b/src/providers/osm.js
@@ -41,6 +41,7 @@ export class OpenStreet {
     return results.map((result) => ({
       lon: result.lon,
       lat: result.lat,
+      bbox: result.boundingbox,
 
       address: {
         name: result.display_name,


### PR DESCRIPTION
- Set `bbox` field appropriately when processing Nominatim response

- Fix bbox transformation to account for Nominatim's formatting

- Include original `place` in addresschosen event