### PR TITLE
Update photon API domain

### DIFF
--- a/src/providers/photon.js
+++ b/src/providers/photon.js
@@ -7,7 +7,7 @@ export class Photon {
    */
   constructor() {
     this.settings = {
-      url: 'https://photon.komoot.de/api/',
+      url: 'https://photon.komoot.io/api/',
 
       params: {
         q: '',


### PR DESCRIPTION
Photon API domain is changing from .de to .io as noted on their website.