### PR TITLE
Correct nominatim URL format

### DIFF
--- a/src/providers/osm.js
+++ b/src/providers/osm.js
@@ -7,7 +7,7 @@ export class OpenStreet {
    */
   constructor() {
     this.settings = {
-      url: 'https://nominatim.openstreetmap.org/search/',
+      url: 'https://nominatim.openstreetmap.org/search',
 
       params: {
         q: '',


### PR DESCRIPTION
Remove trailing '/' from nominatim URL as this URL format is no longer supported:
 /search/?q=query URL format no longer supported (should be /search?q=query) #3134 
https://github.com/osm-search/Nominatim/issues/3134