### PR TITLE
Error on bbox returned by nominatim.js 4.2.0 on Openlayers 7.4.0+

### DIFF
--- a/src/nominatim.js
+++ b/src/nominatim.js
@@ -214,7 +214,7 @@ export class Nominatim {
 
     if (bbox) {
       bbox = proj.transformExtent(
-        [bbox[2], bbox[0], bbox[3], bbox[1]], // SNWE -> WSEN
+        [parseFloat(bbox[2]), parseFloat(bbox[0]), parseFloat(bbox[3]), parseFloat(bbox[1])], // SNWE -> WSEN
         'EPSG:4326',
         projection
       );

--- a/src/nominatim.js
+++ b/src/nominatim.js
@@ -214,7 +214,7 @@ export class Nominatim {
 
     if (bbox) {
       bbox = proj.transformExtent(
-        [bbox[2], bbox[1], bbox[3], bbox[0]], // NSWE -> WSEN
+        [bbox[2], bbox[0], bbox[3], bbox[1]], // SNWE -> WSEN
         'EPSG:4326',
         projection
       );

--- a/src/nominatim.js
+++ b/src/nominatim.js
@@ -2,7 +2,7 @@ import LayerVector from 'ol/layer/Vector';
 import SourceVector from 'ol/source/Vector';
 import Point from 'ol/geom/Point';
 import Feature from 'ol/Feature';
-import proj from 'ol/proj';
+import * as proj from 'ol/proj';
 
 import { VARS, TARGET_TYPE, PROVIDERS, EVENT_TYPE } from '../konstants';
 


### PR DESCRIPTION
There is a bug in receiving the place bounding :
The nominatim doc specify min latitude, max latitude, min longitude, max longitude which means SNWE 
https://nominatim.org/release-docs/latest/api/Output/#boundingbox 

src/nominatim.js line 217
Replace `[bbox[2], bbox[1], bbox[3], bbox[0]], // NSWE -> WSEN`
by `[bbox[2], bbox[0], bbox[3], bbox[1]], // SNWE -> WSEN`

As of 7.4.0++, Openlayers does not accept reversed bboxes and causes mapping issue
